### PR TITLE
Making oar-docker-compose easily scaled with new nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## How to use
 
 - Install [docker-compose](https://docs.docker.com/compose/install/).
-- Build the containers: `cd dev && docker-compose build`.
-- Start the containers: `docker-compose up`.
+- Modify the two variables `NODES` and `CPUS` in file `dev/.env_oar_provisoning.sh`, accordingly.
+- Start the containers: `docker-compose up --build --scale node=NODES`, where NODES is the value of variable from previous step.
 - Connect as user 1 to the frontend `docker exec -u user1 -ti dev_frontend_1 bash` (the name might be different on your commputer).
 - Now you can try to submit a job with `oarsub -I`.
 

--- a/dev/.env_oar_provisoning.sh
+++ b/dev/.env_oar_provisoning.sh
@@ -1,5 +1,7 @@
 #AUTO_PROVISIONING=1
 SRC=""
+NODES=8
+CPUS=2 # per node
 # Enable the frontend to act as a node.
 # In case of job deploy, the oarexec can be executed on the frontend.
 FRONTEND_OAREXEC=false

--- a/dev/common/provisioning.sh
+++ b/dev/common/provisioning.sh
@@ -109,8 +109,58 @@ if [ ! -f /oar_provisioned ]; then
         systemctl enable oar-server
         systemctl start oar-server
 
-        oarnodesetting -a -h node1
-        oarnodesetting -a -h node2
+        #source /etc/systemd/system/create_resources.sh
+        #create_resources_manually
+
+        oarproperty -a cpu || true
+        oarproperty -a core || true
+        oarproperty -c -a host || true
+        oarproperty -a mem || true
+
+        nodes=$NODES
+        cpus=$CPUS
+        cores=$(grep -e "^processor\s\+:" /proc/cpuinfo | sort -u | wc -l)
+        mem=$(grep -e "^MemTotal" /proc/meminfo | awk '{print $2}')
+        mem=$((mem / 1024 / 1024 + 1))
+
+        totalcores=$((cores*cpus*nodes))
+
+        node=0
+        cpu=0
+        node=0
+        for ((core=1;core<=$totalcores; core++)); do
+
+            if (((core-1)%(cpus*cores)==0)); then
+                node=$((node + 1))
+            fi
+
+            if (((core-1)%cores==0)); then
+                cpu=$((cpu + 1))
+            fi
+
+            echo $node $cpu $core $(((core-1)%cores)) >> $log
+            oarnodesetting -a -h "dev_node_"$node -p host="dev_node_"$node -p cpu=$cpu -p core=$core -p cpuset=$(((core-1)%cores)) -p mem=$mem &
+            wait
+        done
+
+        node=0
+        cpu=0
+        node=0
+        for ((core=1;core<=$totalcores; core++)); do
+
+            if (((core-1)%(cpus*cores)==0)); then
+                node=$((node + 1))
+            fi
+
+            if (((core-1)%cores==0)); then
+                cpu=$((cpu + 1))
+            fi
+
+            echo $node $cpu $core $(((core-1)%cores)) >> $log
+            oarnodesetting -r $core -p "cpu=$cpu" -p "core=$core" -p "cpuset=$(((core-1)%cores))" -p mem=$mem &
+            wait
+        done
+
     elif [ "$role" == "node" ] || [[ $FRONTEND_OAREXEC = true && "$role" == "frontend" ]];
     then
         echo "Provision OAR Node for $role"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -35,24 +35,7 @@ services:
     networks:
       - oar
 
-  node1:
-    hostname: node1
-    privileged: true
-    build:
-      context: .
-      target: node
-    tmpfs:
-      - /tmp
-      - /run
-      - /run/lock
-    volumes:
-      - .:/srv
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    networks:
-      - oar
-
-  node2:
-    hostname: node2
+  node:
     privileged: true
     build:
       context: .


### PR DESCRIPTION
This PR promotes a more enhanced version of oar-docker-compose. Specifically, it adds:

- the ability to scale to any number of cluster's nodes by just modifying the variable on one file (`.env_oar_provisoning.sh`) and invoking docker-compose with the respective node parameter
- README file has been modified accordingly (see first 4 lines)
- it automatically creates `host`, `nodes`, `cpu`, `cpuset`, and `core` properties accordingly to the defined variables. Currently, cores are assigned based on system's (host's) capabilities. However, easily can be changed respectively by modifying the number of 'cores' variable.
- Example of run:
```docker-compose -up --scale node=8```, setups an 8 nodes cluster. Also in file (`.env_oar_provisoning.sh`), modifying the lines like:
```
NODES=8
CPUS=2 # per node
```